### PR TITLE
refactor: Align Genre Operations with Domain Conventions Using Guid

### DIFF
--- a/Cinema.Api/Controllers/GenresController.cs
+++ b/Cinema.Api/Controllers/GenresController.cs
@@ -24,15 +24,15 @@ public class GenresController : ApiController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpPut("{id:int}")]
-    public async Task<IActionResult> Update(int id, [FromBody] UpdateGenreDto dto)
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateGenreDto dto)
     {
         return HandleResult(await Mediator.Send(new UpdateGenreCommand(id, dto.Name)));
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpDelete("{id:int}")]
-    public async Task<IActionResult> Delete(int id)
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id) 
     {
         return HandleResult(await Mediator.Send(new DeleteGenreCommand(id)));
     }

--- a/Cinema.Application/Genres/Commands/DeleteGenre/DeleteGenreCommand.cs
+++ b/Cinema.Application/Genres/Commands/DeleteGenre/DeleteGenreCommand.cs
@@ -3,4 +3,4 @@ using MediatR;
 
 namespace Cinema.Application.Genres.Commands.DeleteGenre;
 
-public record DeleteGenreCommand(int ExternalId) : IRequest<Result>;
+public record DeleteGenreCommand(Guid Id) : IRequest<Result>;

--- a/Cinema.Application/Genres/Commands/DeleteGenre/DeleteGenreCommandHandler.cs
+++ b/Cinema.Application/Genres/Commands/DeleteGenre/DeleteGenreCommandHandler.cs
@@ -1,4 +1,6 @@
 using Cinema.Application.Common.Interfaces;
+using Cinema.Domain.Common;
+using Cinema.Domain.Entities;
 using Cinema.Domain.Shared;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -10,11 +12,13 @@ public class DeleteGenreCommandHandler(IApplicationDbContext context)
 {
     public async Task<Result> Handle(DeleteGenreCommand request, CancellationToken ct)
     {
-        var genre = await context.Genres
-            .FirstOrDefaultAsync(g => g.ExternalId == request.ExternalId, ct);
+        var genreId = new EntityId<Genre>(request.Id);
 
-        if (genre == null) return Result.Failure(new Error("Genre.NotFound", "Genre not found"));
+        var genre = await context.Genres.FirstOrDefaultAsync(g => g.Id == genreId, ct);
 
+        if (genre == null) 
+            return Result.Failure(new Error("Genre.NotFound", "Genre not found"));
+        
         context.Genres.Remove(genre);
         await context.SaveChangesAsync(ct);
         

--- a/Cinema.Application/Genres/Commands/UpdateGenre/UpdateGenreCommand.cs
+++ b/Cinema.Application/Genres/Commands/UpdateGenre/UpdateGenreCommand.cs
@@ -3,4 +3,4 @@ using MediatR;
 
 namespace Cinema.Application.Genres.Commands.UpdateGenre;
 
-public record UpdateGenreCommand(int ExternalId, string Name) : IRequest<Result>;
+public record UpdateGenreCommand(Guid Id, string Name) : IRequest<Result>;

--- a/Cinema.Application/Genres/Commands/UpdateGenre/UpdateGenreCommandHandler.cs
+++ b/Cinema.Application/Genres/Commands/UpdateGenre/UpdateGenreCommandHandler.cs
@@ -1,4 +1,6 @@
 using Cinema.Application.Common.Interfaces;
+using Cinema.Domain.Common;
+using Cinema.Domain.Entities;
 using Cinema.Domain.Shared;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -10,8 +12,9 @@ public class UpdateGenreCommandHandler(IApplicationDbContext context)
 {
     public async Task<Result> Handle(UpdateGenreCommand request, CancellationToken ct)
     {
-        var genre = await context.Genres
-            .FirstOrDefaultAsync(g => g.ExternalId == request.ExternalId, ct);
+        var genreId = new EntityId<Genre>(request.Id);
+
+        var genre = await context.Genres.FirstOrDefaultAsync(g => g.Id == genreId, ct);
 
         if (genre == null) return Result.Failure(new Error("Genre.NotFound", "Genre not found"));
 


### PR DESCRIPTION
# refactor: Align Genre Operations with Domain Conventions Using Guid

## 📝 Description

This PR refactors genre-related operations to use `Guid` identifiers instead of `int ExternalId`, aligning the implementation with domain conventions and strongly-typed entity identifiers. These changes ensure consistency across the application layer, API endpoints, and query operations, improving type safety and maintainability.

## 🚀 Key Features

### 🔧 Command Refactoring
*   **DeleteGenreCommand**: Replaced `int ExternalId` with `Guid Id` for proper alignment with `EntityId<Genre>`.
*   **UpdateGenreCommand**: Updated to use `Guid Id` instead of `int ExternalId` for consistency.
*   **Handler Updates**: Adjusted `DeleteGenreCommandHandler` and `UpdateGenreCommandHandler` to work with `EntityId<Genre>` and updated related queries.

### 🌐 API Layer Updates
*   **GenresController**: Changed `Update` and `Delete` action route parameters from `int id` to `Guid id`.
*   **Type Consistency**: Ensures API contracts match domain model conventions across all genre endpoints.

### 🔍 Query Updates
*   **GetMoviesWithPaginationQuery**: Replaced `int? GenreId` with `Guid? GenreId` for genre filtering.
*   **Filtering Logic**: Adjusted query operations to handle `EntityId<Genre>` for consistent entity lookups.

## 🛠 Technical Implementation Details

### Application Layer
*   Updated command DTOs to use `Guid` for identifier properties.
*   Refactored handlers to work with strongly-typed `EntityId<Genre>` instead of primitive integers.
*   Modified query filtering logic to properly handle genre identifier conversions.

### API Layer
*   Updated route parameter types in `GenresController` for `Update` and `Delete` actions.
*   Maintained RESTful conventions while ensuring type safety.

## ⚠️ Breaking Changes
*   **API Endpoints**: Genre `Update` and `Delete` endpoints now accept `Guid` instead of `int` in route parameters.
*   **Client Impact**: Frontend clients must update API calls to use GUID identifiers for genre operations.

## ✅ Checklist
- [x] `DeleteGenreCommand` updated to use `Guid Id`.
- [x] `UpdateGenreCommand` updated to use `Guid Id`.
- [x] Command handlers adjusted to handle `EntityId<Genre>`.
- [x] `GenresController` route parameters updated to `Guid`.
- [x] `GetMoviesWithPaginationQuery` genre filtering updated to use `Guid?`.
- [x] All related queries updated for consistency.

## 🧪 Testing Recommendations
*   Verify genre deletion works correctly with GUID identifiers.
*   Test genre update operations with valid and invalid GUIDs.
*   Confirm movie pagination filtering by genre ID functions properly.
*   Validate API endpoint responses match expected contracts.
*   Test error handling for invalid GUID formats.
