### PR TITLE
Implement automated identity seeding and CLI support

### DIFF
--- a/Cinema.Api/Modules/WebApplicationExtensions.cs
+++ b/Cinema.Api/Modules/WebApplicationExtensions.cs
@@ -1,5 +1,6 @@
 using Cinema.Api.Hubs;
 using Cinema.Infrastructure.Persistence;
+using Cinema.Infrastructure.Seed;
 
 namespace Cinema.Api.Modules;
 
@@ -13,19 +14,30 @@ public static class WebApplicationExtensions
 
     public static async Task InitialiseDatabaseAsync(this WebApplication app)
     {
-        if (!app.Environment.IsDevelopment()) return;
-
         using var scope = app.Services.CreateScope();
-        try 
+        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("DatabaseInitialisation");
+
+        try
         {
             var initialiser = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
+
             await initialiser.InitialiseAsync();
             await initialiser.SeedAsync();
+
+            await app.SeedIdentityAsync(scope.ServiceProvider);
         }
         catch (Exception ex)
         {
-            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-            logger.LogError(ex, "An error occurred during database initialisation.");
+            logger.LogError(ex, "An error occurred during database initialisation/seeding.");
+            throw;
         }
+    }
+
+    public static async Task SeedIdentityAsync(this WebApplication app, IServiceProvider sp)
+    {
+        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("IdentitySeeder");
+
+        await IdentitySeeder.SeedAsync(sp, app.Configuration, logger);
     }
 }

--- a/Cinema.Api/Program.cs
+++ b/Cinema.Api/Program.cs
@@ -11,7 +11,38 @@ builder.Host.UseSerilog((context, configuration) =>
 builder.Services.AddWebServices(builder.Configuration);
 
 var app = builder.Build();
-await app.InitialiseDatabaseAsync();
+
+// Seed mode detection (either via CLI argument '--seed' or SEED__MODE environment variable)
+var isSeedMode = args.Contains("--seed") || 
+                 string.Equals(app.Configuration["SEED__MODE"], "true", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(app.Configuration["Seed__Mode"], "true", StringComparison.OrdinalIgnoreCase);
+
+if (isSeedMode)
+{
+    using (var scope = app.Services.CreateScope())
+    {
+        var sp = scope.ServiceProvider;
+        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("SeederCommandLine");
+        try
+        {
+            logger.LogInformation("CLI/Env seed mode detected. Running identity seeding...");
+            await Cinema.Infrastructure.Seed.IdentitySeeder.SeedAsync(sp, app.Configuration, logger);
+            logger.LogInformation("Identity seeding completed successfully.");
+            Environment.Exit(0);
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "An error occurred during CLI/Env identity seeding.");
+            Environment.Exit(1);
+        }
+    }
+}
+
+if (app.Environment.IsDevelopment())
+{
+    await app.InitialiseDatabaseAsync();
+}
+
 app.UseExceptionHandler();
 app.UseSerilogRequestLogging();
 app.UseMiddleware<RequestLogContextMiddleware>();

--- a/Cinema.Infrastructure/Seed/IdentitySeeder.cs
+++ b/Cinema.Infrastructure/Seed/IdentitySeeder.cs
@@ -1,0 +1,119 @@
+using Cinema.Domain.Entities;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cinema.Infrastructure.Seed;
+
+public static class IdentitySeeder
+{
+    public static async Task SeedAsync(IServiceProvider sp, IConfiguration config, ILogger logger)
+    {
+        var seedRun = config["Seed:Run"] ?? 
+                      config["SEED__RUN"] ?? 
+                      Environment.GetEnvironmentVariable("SEED__RUN");
+        var hostEnvironment = sp.GetRequiredService<IHostEnvironment>();
+        
+        bool isProduction = hostEnvironment.IsProduction();
+        
+        bool isSeedRunEnabled;
+        if (!string.IsNullOrEmpty(seedRun))
+        {
+            isSeedRunEnabled = string.Equals(seedRun, "true", StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            // Default to true in Development, false in Production/other environments
+            isSeedRunEnabled = !isProduction;
+        }
+
+        if (!isSeedRunEnabled)
+        {
+            logger.LogInformation("Database seeding is disabled. Skipping.");
+            return;
+        }
+
+        logger.LogInformation("Starting identity seeding process...");
+
+        var roleManager = sp.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
+        var userManager = sp.GetRequiredService<UserManager<User>>();
+
+        // Seed Roles
+        string[] roles = ["User", "Admin"];
+        foreach (var roleName in roles)
+        {
+            if (!await roleManager.RoleExistsAsync(roleName))
+            {
+                logger.LogInformation("Creating role: {Role}", roleName);
+                var roleResult = await roleManager.CreateAsync(new IdentityRole<Guid>(roleName));
+                if (!roleResult.Succeeded)
+                {
+                    var errors = string.Join(", ", roleResult.Errors.Select(e => e.Description));
+                    logger.LogError("Failed to create role {Role}: {Errors}", roleName, errors);
+                    throw new Exception($"Failed to create role {roleName}: {errors}");
+                }
+            }
+        }
+
+        // Seed Admin User
+        var adminEmail = config["SeedAdmin:Email"] ?? 
+                         config["SEED_ADMIN__EMAIL"] ?? 
+                         Environment.GetEnvironmentVariable("SEED_ADMIN__EMAIL");
+        var adminPassword = config["SeedAdmin:Password"] ?? 
+                            config["SEED_ADMIN__PASSWORD"] ?? 
+                            Environment.GetEnvironmentVariable("SEED_ADMIN__PASSWORD");
+        var firstName = config["SeedAdmin:FirstName"] ?? 
+                        config["SEED_ADMIN__FIRSTNAME"] ?? 
+                        Environment.GetEnvironmentVariable("SEED_ADMIN__FIRSTNAME") ?? 
+                        "System";
+        var lastName = config["SeedAdmin:LastName"] ?? 
+                       config["SEED_ADMIN__LASTNAME"] ?? 
+                       Environment.GetEnvironmentVariable("SEED_ADMIN__LASTNAME") ?? 
+                       "Admin";
+
+        if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword))
+        {
+            logger.LogWarning("Seed admin credentials are not set (SEED_ADMIN__EMAIL / SEED_ADMIN__PASSWORD). Skipping admin user seeding.");
+            return;
+        }
+
+        var adminUser = await userManager.FindByEmailAsync(adminEmail);
+        if (adminUser == null)
+        {
+            logger.LogInformation("Seeding default admin user: {Email}", adminEmail);
+            adminUser = new User
+            {
+                UserName = adminEmail,
+                Email = adminEmail,
+                FirstName = firstName,
+                LastName = lastName,
+                EmailConfirmed = true
+            };
+
+            var createResult = await userManager.CreateAsync(adminUser, adminPassword);
+            if (!createResult.Succeeded)
+            {
+                var errors = string.Join(", ", createResult.Errors.Select(e => e.Description));
+                logger.LogError("Failed to seed admin user: {Errors}", errors);
+                throw new Exception($"Failed to seed admin user: {errors}");
+            }
+        }
+
+        if (!await userManager.IsInRoleAsync(adminUser, "Admin"))
+        {
+            logger.LogInformation("Assigning Admin role to user: {Email}", adminEmail);
+            var roleResult = await userManager.AddToRoleAsync(adminUser, "Admin");
+            if (!roleResult.Succeeded)
+            {
+                var errors = string.Join(", ", roleResult.Errors.Select(e => e.Description));
+                logger.LogError("Failed to assign Admin role: {Errors}", errors);
+                throw new Exception($"Failed to assign Admin role: {errors}");
+            }
+        }
+
+        logger.LogInformation("Identity seeding completed successfully.");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -391,6 +391,39 @@ The `docker-compose.yaml` includes:
 - `SMTP_PASSWORD` — SMTP password
 - `SMTP_SENDER_EMAIL` — Sender email address
 
+## 🔄 Database Migrations & Seeding in Production
+
+In Production (`ASPNETCORE_ENVIRONMENT=Production`), database migrations and identity seeding are not executed automatically on API startup to ensure zero-downtime and safe deployment practices. Instead, they are run as separate steps:
+
+### 1. Database Migrations (cinema-migrator)
+Migrations are run using a separate container (e.g. `cinema-migrator`) that executes `dotnet ef database update`.
+
+### 2. Database Seeding (cinema-seeder)
+Seeding of default Identity roles (`Admin`, `User`) and the default admin user is executed via a separate one-off job container `cinema-seeder`.
+
+#### Configuration / Environment Variables
+The seeder is controlled by the following environment variables (which can be defined in your `.env` file):
+
+- `SEED__RUN` (bool) — Enables/disables execution of the seeder. Defaults to `true` in Development and `false` in Production. It must be explicitly set to `true` in Production for seeding to run.
+- `SEED__MODE` (bool) — Sets the API into CLI seeding mode. If `true` or the command line flag `--seed` is passed, the API runs seeding and exits immediately with code 0 (or 1 on error).
+- `SEED_ADMIN__EMAIL` (string) — The email address of the default Admin user to create.
+- `SEED_ADMIN__PASSWORD` (string) — The password for the default Admin user.
+- `SEED_ADMIN__FIRSTNAME` (string, optional) — First name of the Admin user (defaults to `System`).
+- `SEED_ADMIN__LASTNAME` (string, optional) — Last name of the Admin user (defaults to `Admin`).
+
+#### Running with Docker Compose
+You can run the seeding process using the `cinema-seeder` service defined in `docker-compose.yaml`:
+
+```bash
+# Start the seeder manually (it will wait for the database and exit once done)
+docker compose run --rm cinema-seeder
+```
+
+Or pass variables explicitly if you want to override them:
+```bash
+docker compose run --rm -e SEED_ADMIN__EMAIL=admin@example.com -e SEED_ADMIN__PASSWORD=SecretPassword123! cinema-seeder
+```
+
 ---
 
 ## 📧 Email Configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d cinema_local_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   cinema-redis:
     image: redis:alpine
@@ -46,6 +51,28 @@ services:
       - "5433:5432"
     volumes:
       - loyalty_pg_data:/var/lib/postgresql/data
+
+  # === СЕРВІС СІДИНГУ ===
+  cinema-seeder:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    container_name: cinema-seeder
+    restart: "no"
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - SEED__RUN=true
+      - SEED__MODE=true
+      - ConnectionStrings__DefaultConnection=Host=cinema-db;Port=5432;Database=cinema_local_db;Username=postgres;Password=postgres_password
+      - ConnectionStrings__RedisConnection=cinema-redis:6379,password=redis_password
+      - RabbitMQ__Host=cinema-rabbitmq
+      - SEED_ADMIN__EMAIL=admin@cinema.com
+      - SEED_ADMIN__PASSWORD=Admin123!
+    entrypoint: ["dotnet", "run", "--project", "Cinema.Api", "--", "--seed"]
+    depends_on:
+      cinema-db:
+        condition: service_healthy
 
 volumes:
   postgres_data:


### PR DESCRIPTION
This pull request introduces a robust and flexible system for seeding identity data (roles and admin user) in the Cinema API, with special consideration for safe production deployments. It adds a dedicated seeder service, environment-based configuration, and command-line/CI-friendly seeding modes, along with clear documentation and Docker Compose integration.

**Identity Seeding System and Production Safety**

* Added a new `IdentitySeeder` utility (`Cinema.Infrastructure.Seed.IdentitySeeder`) that seeds default roles (`Admin`, `User`) and a default admin user, configurable via environment variables. Seeding is enabled by default in development but must be explicitly enabled in production for safety. (`[Cinema.Infrastructure/Seed/IdentitySeeder.csR1-R119](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377R1-R119)`)
* Seeding can be triggered on API startup via a special CLI flag (`--seed`) or the `SEED__MODE` environment variable, causing the app to run the seeding logic and exit. This allows for safe, one-off seeding jobs in production/CI. (`[Cinema.Api/Program.csR14-R45](diffhunk://#diff-9f5487a1c27834f9dcce86972a9d6e6dfb9e9465e02a4a7547698af05b4970f2R14-R45)`)
* Refactored API startup (`WebApplicationExtensions.cs`) to support both normal and CLI-based seeding, with improved logging and error handling. (`[[1]](diffhunk://#diff-3b173efe9cdb6053514a0ae7061fa73c7efed2669cc62526c8122b41a6dcb40dR3)`, `[[2]](diffhunk://#diff-3b173efe9cdb6053514a0ae7061fa73c7efed2669cc62526c8122b41a6dcb40dL16-R42)`)

**Docker & Deployment Integration**

* Added a dedicated `cinema-seeder` service to `docker-compose.yaml` for running the seeding process as a separate job/container, with appropriate environment variables and dependency on a healthy database. (`[docker-compose.yamlR55-R76](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R55-R76)`)
* Added a healthcheck for the `cinema-db` service to ensure the database is ready before seeding begins. (`[docker-compose.yamlR16-R20](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R16-R20)`)

**Documentation**

* Updated the `README.md` with clear instructions for running migrations and seeding in production, including environment variable descriptions, Docker Compose usage, and safety notes. (`[README.mdR394-R426](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R394-R426)`)