### PR TITLE
Implement database initialization and identity role seeding

### DIFF
--- a/Cinema.Api/Modules/WebApplicationExtensions.cs
+++ b/Cinema.Api/Modules/WebApplicationExtensions.cs
@@ -24,8 +24,6 @@ public static class WebApplicationExtensions
 
             await initialiser.InitialiseAsync();
             await initialiser.SeedAsync();
-
-            await app.SeedIdentityAsync(scope.ServiceProvider);
         }
         catch (Exception ex)
         {
@@ -34,10 +32,30 @@ public static class WebApplicationExtensions
         }
     }
 
-    public static async Task SeedIdentityAsync(this WebApplication app, IServiceProvider sp)
+    public static async Task SeedIdentityIfEnabledAsync(this WebApplication app)
     {
-        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("IdentitySeeder");
+        var enabledStr = app.Configuration["SeedIdentity:Enabled"] 
+                         ?? Environment.GetEnvironmentVariable("SeedIdentity__Enabled")
+                         ?? Environment.GetEnvironmentVariable("SEED_IDENTITY__ENABLED");
+                         
+        if (!string.Equals(enabledStr, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
 
-        await IdentitySeeder.SeedAsync(sp, app.Configuration, logger);
+        using var scope = app.Services.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("IdentitySeeder");
+
+        try
+        {
+            logger.LogInformation("Identity seeding enabled, starting...");
+            await IdentitySeeder.SeedAsync(scope.ServiceProvider, app.Configuration, logger);
+            logger.LogInformation("Identity seeding completed.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred during identity seeding.");
+            throw;
+        }
     }
 }

--- a/Cinema.Api/Program.cs
+++ b/Cinema.Api/Program.cs
@@ -12,36 +12,12 @@ builder.Services.AddWebServices(builder.Configuration);
 
 var app = builder.Build();
 
-// Seed mode detection (either via CLI argument '--seed' or SEED__MODE environment variable)
-var isSeedMode = args.Contains("--seed") || 
-                 string.Equals(app.Configuration["SEED__MODE"], "true", StringComparison.OrdinalIgnoreCase) ||
-                 string.Equals(app.Configuration["Seed__Mode"], "true", StringComparison.OrdinalIgnoreCase);
-
-if (isSeedMode)
-{
-    using (var scope = app.Services.CreateScope())
-    {
-        var sp = scope.ServiceProvider;
-        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("SeederCommandLine");
-        try
-        {
-            logger.LogInformation("CLI/Env seed mode detected. Running identity seeding...");
-            await Cinema.Infrastructure.Seed.IdentitySeeder.SeedAsync(sp, app.Configuration, logger);
-            logger.LogInformation("Identity seeding completed successfully.");
-            Environment.Exit(0);
-        }
-        catch (Exception ex)
-        {
-            logger.LogCritical(ex, "An error occurred during CLI/Env identity seeding.");
-            Environment.Exit(1);
-        }
-    }
-}
-
 if (app.Environment.IsDevelopment())
 {
     await app.InitialiseDatabaseAsync();
 }
+
+await app.SeedIdentityIfEnabledAsync();
 
 app.UseExceptionHandler();
 app.UseSerilogRequestLogging();

--- a/Cinema.Infrastructure/Seed/IdentitySeeder.cs
+++ b/Cinema.Infrastructure/Seed/IdentitySeeder.cs
@@ -1,9 +1,7 @@
 using Cinema.Domain.Entities;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Cinema.Infrastructure.Seed;
@@ -12,42 +10,14 @@ public static class IdentitySeeder
 {
     public static async Task SeedAsync(IServiceProvider sp, IConfiguration config, ILogger logger)
     {
-        var seedRun = config["Seed:Run"] ?? 
-                      config["SEED__RUN"] ?? 
-                      Environment.GetEnvironmentVariable("SEED__RUN");
-        var hostEnvironment = sp.GetRequiredService<IHostEnvironment>();
-        
-        bool isProduction = hostEnvironment.IsProduction();
-        
-        bool isSeedRunEnabled;
-        if (!string.IsNullOrEmpty(seedRun))
-        {
-            isSeedRunEnabled = string.Equals(seedRun, "true", StringComparison.OrdinalIgnoreCase);
-        }
-        else
-        {
-            // Default to true in Development, false in Production/other environments
-            isSeedRunEnabled = !isProduction;
-        }
-
-        if (!isSeedRunEnabled)
-        {
-            logger.LogInformation("Database seeding is disabled. Skipping.");
-            return;
-        }
-
-        logger.LogInformation("Starting identity seeding process...");
-
         var roleManager = sp.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
         var userManager = sp.GetRequiredService<UserManager<User>>();
 
-        // Seed Roles
-        string[] roles = ["User", "Admin"];
+        string[] roles = ["USER", "ADMIN"];
         foreach (var roleName in roles)
         {
             if (!await roleManager.RoleExistsAsync(roleName))
             {
-                logger.LogInformation("Creating role: {Role}", roleName);
                 var roleResult = await roleManager.CreateAsync(new IdentityRole<Guid>(roleName));
                 if (!roleResult.Succeeded)
                 {
@@ -57,39 +27,25 @@ public static class IdentitySeeder
                 }
             }
         }
+        logger.LogInformation("Roles ensured...");
 
-        // Seed Admin User
-        var adminEmail = config["SeedAdmin:Email"] ?? 
-                         config["SEED_ADMIN__EMAIL"] ?? 
-                         Environment.GetEnvironmentVariable("SEED_ADMIN__EMAIL");
-        var adminPassword = config["SeedAdmin:Password"] ?? 
-                            config["SEED_ADMIN__PASSWORD"] ?? 
-                            Environment.GetEnvironmentVariable("SEED_ADMIN__PASSWORD");
-        var firstName = config["SeedAdmin:FirstName"] ?? 
-                        config["SEED_ADMIN__FIRSTNAME"] ?? 
-                        Environment.GetEnvironmentVariable("SEED_ADMIN__FIRSTNAME") ?? 
-                        "System";
-        var lastName = config["SeedAdmin:LastName"] ?? 
-                       config["SEED_ADMIN__LASTNAME"] ?? 
-                       Environment.GetEnvironmentVariable("SEED_ADMIN__LASTNAME") ?? 
-                       "Admin";
+        var adminEmail = config["SeedAdmin:Email"] ?? Environment.GetEnvironmentVariable("SeedAdmin__Email") ?? Environment.GetEnvironmentVariable("SEED_ADMIN__EMAIL");
+        var adminPassword = config["SeedAdmin:Password"] ?? Environment.GetEnvironmentVariable("SeedAdmin__Password") ?? Environment.GetEnvironmentVariable("SEED_ADMIN__PASSWORD");
 
         if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword))
         {
-            logger.LogWarning("Seed admin credentials are not set (SEED_ADMIN__EMAIL / SEED_ADMIN__PASSWORD). Skipping admin user seeding.");
             return;
         }
 
         var adminUser = await userManager.FindByEmailAsync(adminEmail);
         if (adminUser == null)
         {
-            logger.LogInformation("Seeding default admin user: {Email}", adminEmail);
             adminUser = new User
             {
                 UserName = adminEmail,
                 Email = adminEmail,
-                FirstName = firstName,
-                LastName = lastName,
+                FirstName = "System",
+                LastName = "Admin",
                 EmailConfirmed = true
             };
 
@@ -102,18 +58,17 @@ public static class IdentitySeeder
             }
         }
 
-        if (!await userManager.IsInRoleAsync(adminUser, "Admin"))
+        if (!await userManager.IsInRoleAsync(adminUser, "ADMIN"))
         {
-            logger.LogInformation("Assigning Admin role to user: {Email}", adminEmail);
-            var roleResult = await userManager.AddToRoleAsync(adminUser, "Admin");
+            var roleResult = await userManager.AddToRoleAsync(adminUser, "ADMIN");
             if (!roleResult.Succeeded)
             {
                 var errors = string.Join(", ", roleResult.Errors.Select(e => e.Description));
-                logger.LogError("Failed to assign Admin role: {Errors}", errors);
-                throw new Exception($"Failed to assign Admin role: {errors}");
+                logger.LogError("Failed to assign ADMIN role: {Errors}", errors);
+                throw new Exception($"Failed to assign ADMIN role: {errors}");
             }
         }
 
-        logger.LogInformation("Identity seeding completed successfully.");
+        logger.LogInformation("Admin ensured...");
     }
 }


### PR DESCRIPTION
This pull request refactors and simplifies the identity seeding process for the application, making it more configurable and robust. The main improvements include removing legacy seed mode logic, centralizing configuration checks, and standardizing role naming conventions.

**Configuration and Seeding Logic Improvements:**

* Removed CLI/environment-based "seed mode" logic from `Program.cs`, and replaced it with a single call to `SeedIdentityIfEnabledAsync`, which checks configuration/environment variables to determine if identity seeding should run.
* Refactored `SeedIdentityAsync` to `SeedIdentityIfEnabledAsync` in `WebApplicationExtensions.cs`, so identity seeding is now controlled by a `SeedIdentity:Enabled` configuration value or corresponding environment variable. [[1]](diffhunk://#diff-3b173efe9cdb6053514a0ae7061fa73c7efed2669cc62526c8122b41a6dcb40dL27-L28) [[2]](diffhunk://#diff-3b173efe9cdb6053514a0ae7061fa73c7efed2669cc62526c8122b41a6dcb40dL37-R59)

**Identity Seeder Simplification and Standardization:**

* Simplified `IdentitySeeder.SeedAsync` by removing the `Seed:Run` logic and always attempting to seed if called; also removed unnecessary dependencies and streamlined environment/configuration variable lookups for admin credentials. [[1]](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377L2-L6) [[2]](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377L15-L50) [[3]](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377R30-R48)
* Standardized role names to uppercase (`"USER"`, `"ADMIN"`), and ensured admin user is always created with the default first and last name ("System", "Admin"). [[1]](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377L15-L50) [[2]](diffhunk://#diff-2484a04f078b6bf2678250809023280cce4e86ddc67f1d485c00a4c5f232b377R30-R48)
* Ensured admin user is assigned the `"ADMIN"` role (uppercase), and improved related logging.